### PR TITLE
feat: Add sample name argument to sample plots

### DIFF
--- a/src/plot/command.rs
+++ b/src/plot/command.rs
@@ -27,7 +27,11 @@ pub struct FilepathResults<'a>(pub &'a PathBuf, pub Results);
 pub trait SamplePlot {
     fn name(&self) -> &'static str;
     fn filename(&self) -> &'static str;
-    fn generate(&self, filepath_results: &FilepathResults<'_>) -> anyhow::Result<plotly::Plot>;
+    fn generate(
+        &self,
+        filepath_results: &FilepathResults<'_>,
+        sample: Option<&String>,
+    ) -> anyhow::Result<plotly::Plot>;
 }
 
 //===================//

--- a/src/plot/sample.rs
+++ b/src/plot/sample.rs
@@ -30,6 +30,14 @@ pub fn get_command<'a>() -> Command<'a> {
                 .required(false)
                 .takes_value(true),
         )
+        .arg(
+            Arg::new("sample")
+                .help("sample name to include in plot title")
+                .long("--sample")
+                .short('s')
+                .required(false)
+                .takes_value(true),
+        )
 }
 
 pub fn plot(matches: &ArgMatches) -> anyhow::Result<()> {
@@ -57,10 +65,17 @@ pub fn plot(matches: &ArgMatches) -> anyhow::Result<()> {
 
     let plots = get_all_sample_plots();
     for p in plots {
-        let plot = p.generate(&results)?;
+        let plot = p.generate(&results, matches.get_one::<String>("sample"))?;
 
         let mut filename = output_directory.clone();
-        filename.push(String::from(p.filename()) + ".sample.html");
+        match matches.get_one::<String>("sample") {
+            Some(a) => {
+                filename.push(format!("{}.{}.sample.html", a, p.filename()));
+            }
+            None => {
+                filename.push(String::from(p.filename()) + ".sample.html");
+            }
+        }
 
         info!("  [*] Writing {} to {}", p.name(), filename.display());
         plot.write_html(filename);

--- a/src/plot/sample/gc_content_distribution.rs
+++ b/src/plot/sample/gc_content_distribution.rs
@@ -18,7 +18,11 @@ impl SamplePlot for GCContentDistributionPlot {
         "gc-content-distribution"
     }
 
-    fn generate(&self, filepath_results: &FilepathResults<'_>) -> anyhow::Result<plotly::Plot> {
+    fn generate(
+        &self,
+        filepath_results: &FilepathResults<'_>,
+        sample: Option<&String>,
+    ) -> anyhow::Result<plotly::Plot> {
         let mut plot = plotly::Plot::new();
         let FilepathResults(filepath, results) = filepath_results;
 
@@ -78,8 +82,13 @@ impl SamplePlot for GCContentDistributionPlot {
         plot.add_trace(trace);
 
         // (6) Configure the graph for plotting and return.
+        let title = match sample {
+            Some(s) => format!("{} - {}", self.name(), s.clone()),
+            None => self.name().to_string(),
+        };
+
         let layout = Layout::new()
-            .title(Title::new(self.name()))
+            .title(Title::new(title.as_str()))
             .x_axis(
                 Axis::new()
                     .title(Title::new("Percentage GC"))

--- a/src/plot/sample/quality_score_distribution.rs
+++ b/src/plot/sample/quality_score_distribution.rs
@@ -19,7 +19,11 @@ impl SamplePlot for QualityScoreDistributionPlot {
         "quality-score-distribution"
     }
 
-    fn generate(&self, filepath_results: &FilepathResults<'_>) -> anyhow::Result<plotly::Plot> {
+    fn generate(
+        &self,
+        filepath_results: &FilepathResults<'_>,
+        sample: Option<&String>,
+    ) -> anyhow::Result<plotly::Plot> {
         let mut plot = plotly::Plot::new();
         let FilepathResults(filepath, results) = filepath_results;
 
@@ -81,8 +85,12 @@ impl SamplePlot for QualityScoreDistributionPlot {
         plot.add_trace(trace);
 
         // (5) Configure the graph for plotting and return.
+        let title = match sample {
+            Some(s) => format!("{} - {}", self.name(), s.clone()),
+            None => self.name().to_string(),
+        };
         let layout = Layout::new()
-            .title(Title::new(self.name()))
+            .title(Title::new(title.as_str()))
             .x_axis(Axis::new().title(Title::new("Position")).auto_range(true))
             .y_axis(
                 Axis::new()


### PR DESCRIPTION
Implements a sample name parameter to the plot methods. This sample name gets included in the plot titles and is used as a prefix for the output files.