### PR TITLE
Docker Build and Documentation

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -16,8 +16,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v3
-      - name: qemu setup
-        uses: docker/setup-qemu-action@v2
       - name: login
         run: echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - name: buildx setup

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,36 @@
+name: Docker Release
+
+on:
+  workflow_dispatch:
+
+# Ensure single workflow runs at a time
+# Runs that are already underway will be canceled when a new job is queued
+# See <https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency>
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: qemu setup
+        uses: docker/setup-qemu-action@v2
+      - name: login
+        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: buildx setup
+        uses: docker/setup-buildx-action@v2
+      - name: build
+        run: |
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            --tag ghcr.io/${{ github.repository }}:latest \
+            --tag ghcr.io/${{ github.repository }}:${{ github.ref_name }} \
+            --pull \
+            --load \
+            --no-cache \
+            .
+      - name: push
+        run: docker push ghcr.io/${{ github.repository }} --all-tags

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 
 *.json
 *.html
+
+# Ignoring test data
+*.bam
+*.bai

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# This Dockerfile builds on debian:buster-slim to include the ngs tool
+# from the current working directory.
+#
+# This produces a docker imange that contains a worker ngs binary. Images
+# released on the Github container registry are build using this file.
+
+FROM rust:1.64-slim-buster AS builder
+
+WORKDIR /usr/src/ngs
+
+COPY Cargo.toml .
+COPY Cargo.lock .
+COPY src ./src
+
+RUN cargo install --path .
+
+FROM debian:buster-slim
+LABEL maintainer="Keivn Benton <krbenton.opensource@icloud.com>"
+
+COPY --from=builder /usr/local/cargo/bin/ngs /usr/local/bin/ngs
+
+WORKDIR /data
+
+ENTRYPOINT ["ngs"]

--- a/README.md
+++ b/README.md
@@ -70,6 +70,19 @@ To install the latest version on `main`, you can use the following command.
 cargo install --locked --git https://github.com/stjude-rust-labs/ngs.git
 ```
 
+### Using Docker
+
+```bash
+docker pull ghcr.io/stjude-rust-labs/ngs
+docker run -it --rm --volume "$(pwd)":/data ghcr.io/stjude-rust-labs/ngs
+```
+
+`/data` is the working directory of the docker image. Running this command from the directory with your data will allow
+the continer to act on those files.
+
+Note: Currently the `latest` tag refers to the latest release of `ngs` and not the most recent code changes in this
+repository.
+
 ## 🖥️ Development
 
 To bootstrap a development environment, please use the following commands.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,3 +12,4 @@
   * [ ] Publish the new crate: `cargo publish`.
   * [ ] Go to the Releases page in Github, create a Release for this tag, and
     copy the notes from the `CHANGELOG.md` file.
+  * [ ] Run docker release workflow from release tag branch.


### PR DESCRIPTION
Adding docker tooling based on debian:buster-slim to create an `ngs` image like other cli tools such as `terraform`, `checkov`, etc. Image size is approximately 200 MB after build. Image is also built for `linux/amd64` and `linux/arm64` platforms.

Additionally added documentation for using the docker image, a manual release pipeline to push to github container registry, and added the step in the release document.

Release pipeline is untested as it has been difficult to test locally with all the predefined variables to use. Also not sure of the permissions around ghcr so there may be some tweaks needed after this is merged and ran.
