### PR TITLE
Push Images from buildx command

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -27,8 +27,6 @@ jobs:
             --tag ghcr.io/${{ github.repository }}:latest \
             --tag ghcr.io/${{ github.repository }}:${{ github.ref_name }} \
             --pull \
-            --load \
+            --push \
             --no-cache \
             .
-      - name: push
-        run: docker push ghcr.io/${{ github.repository }} --all-tags


### PR DESCRIPTION
When building for multiple architectures using the `buildx` command, you cannot use the `--load` option. I have replaced the previous push step but using the `--push` flag in the command.